### PR TITLE
Fix RemoveQuotes function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+Purpose: Provide coding guidelines and instructions for working on this repository.
+
+# Repository Overview
+- This project implements "rlvm", a free reimplementation of VisualArt's/Key's RealLive interpreter used to run VisualArts games. The main code lives in `src/` and is split into subdirectories like `core`, `libreallive`, `libsiglus`, `machine`, `modules`, `systems`, `vm`, and `m6`.
+- Tests are under `test/` and use GoogleTest.
+- Third‑party libraries live in `vendor/`.
+- Developer notes and format documentation are in `doc/`.
+
+# Building
+1. Ensure dependencies from the README are installed (CMake≥3.18, Boost, SDL 1.2, OpenGL, etc.).
+2. Configure and build:
+   ```bash
+   cmake -S . -B build -G "<generator>"
+   cmake --build build
+   ```
+3. The main executable is `./build/rlvm`.
+
+# Running Unit Tests
+1. Configure with tests enabled and build:
+   ```bash
+   cmake -S . -B build -DRLVM_BUILD_TESTS=ON
+   cmake --build build
+   ```
+2. Execute tests with:
+   ```bash
+   ./build/unittest
+   ```
+
+# Coding Style
+- The repository uses a `.clang-format` file derived from the Chromium style. Run `clang-format -i` on changed C++ files before committing.
+
+# Pull Request Guidelines
+- Describe the purpose of your changes and reference relevant files or functions.
+- Include test results from running `./build/unittest`.

--- a/src/utilities/string_utilities.cpp
+++ b/src/utilities/string_utilities.cpp
@@ -184,10 +184,12 @@ void PrintTextToFunction(
 
 string RemoveQuotes(const string& quotedString) {
   string output = quotedString;
-  if (output.size() && output[0] == '\"')
-    output = output.substr(1);
-  if (output.size() && output[output.size() - 1] == '\"')
-    output = output.substr(0, output.size() - 2);
+
+  if (!output.empty() && output.front() == '"')
+    output.erase(0, 1);
+
+  if (!output.empty() && output.back() == '"')
+    output.pop_back();
 
   return output;
 }

--- a/test/string_utils_unittest.cpp
+++ b/test/string_utils_unittest.cpp
@@ -39,5 +39,5 @@ TEST(StringUtilTest, RemoveQuotes) {
   EXPECT_EQ(RemoveQuotes("\"hello\""), "hello");
   EXPECT_EQ(RemoveQuotes("hello"), "hello");
   EXPECT_EQ(RemoveQuotes(""), "");
-  EXPECT_EQ(RemoveQuotes("\"a\"b\""), "a\"b\"");
+  EXPECT_EQ(RemoveQuotes("\"a\"b\""), "a\"b");
 }

--- a/test/string_utils_unittest.cpp
+++ b/test/string_utils_unittest.cpp
@@ -34,3 +34,10 @@ TEST(StringUtilTest, Join) {
                                  [](int x) { return std::to_string(x); })),
             "1, 2, 3");
 }
+
+TEST(StringUtilTest, RemoveQuotes) {
+  EXPECT_EQ(RemoveQuotes("\"hello\""), "hello");
+  EXPECT_EQ(RemoveQuotes("hello"), "hello");
+  EXPECT_EQ(RemoveQuotes(""), "");
+  EXPECT_EQ(RemoveQuotes("\"a\"b\""), "a\"b\"");
+}


### PR DESCRIPTION
## Summary
- fix `RemoveQuotes` to correctly strip only the outer quotes
- cover RemoveQuotes behaviour with unit tests

## Testing
- `cmake .. -DRLVM_BUILD_TESTS=ON` *(fails: missing third-party libraries)*
- `ctest --output-on-failure` *(fails: no tests were built)*

------
https://chatgpt.com/codex/tasks/task_e_683f485cd1b083249ae123536c7f341c