### PR TITLE
Implement python-like function params

### DIFF
--- a/src/m6/ast.cpp
+++ b/src/m6/ast.cpp
@@ -193,8 +193,14 @@ struct Dumper {
     }
     if constexpr (std::same_as<T, FuncDecl>) {
       for (size_t i = 0; i < x.default_params.size(); ++i) {
-        oss << x.default_params[i].second->DumpAST(
-            "default " + x.default_params[i].first, childPrefix, false);
+        const auto& [default_name, default_expr_ast] = x.default_params[i];
+
+        if (!default_expr_ast)
+          oss << childPrefix << "├─"
+              << "default " + default_name << '\n';
+        else
+          oss << x.default_params[i].second->DumpAST("default " + default_name,
+                                                     childPrefix, false);
       }
       oss << x.body->DumpAST("body", childPrefix, true);
     }

--- a/src/m6/ast.hpp
+++ b/src/m6/ast.hpp
@@ -242,11 +242,21 @@ struct BlockStmt {
 
 struct FuncDecl {
   std::string name;
-  std::vector<std::string> params;
+  std::vector<std::string>
+      params;  // Ordered list of required (no-default) parameters
+  std::vector<std::pair<std::string, std::shared_ptr<ExprAST>>>
+      default_params;  // Ordered list of parameters that have defaults, plus
+                       // their default Value
+  std::string
+      var_arg;  // Name for a varargs ("*args") parameter, or empty if none
+  std::string kw_arg;  // Name for a varkeywords ("**kwargs") parameter, or
+                       // empty if none
+
   std::shared_ptr<AST> body;  // guaranteed BlockStmt
 
   SourceLocation name_loc;
-  std::vector<SourceLocation> param_locs;
+  std::vector<SourceLocation> param_locs, def_params_loc;
+  SourceLocation var_arg_loc, kw_arg_loc;
 
   std::string DebugString() const;
 };

--- a/src/m6/parser.hpp
+++ b/src/m6/parser.hpp
@@ -144,6 +144,16 @@ class Parser {
   std::shared_ptr<ExprAST> parsePostfix();
   std::shared_ptr<ExprAST> parsePrimary();
 
+  bool ScanParameterList(
+      std::vector<std::string>& required,
+      std::vector<SourceLocation>& requiredLocs,
+      std::vector<std::pair<std::string, std::shared_ptr<ExprAST>>>& defaulted,
+      std::vector<SourceLocation>& defaultedLocs,
+      std::string& varArg,
+      SourceLocation& varArgLoc,
+      std::string& kwArg,
+      SourceLocation& kwArgLoc);
+
  private:
   //------------------------------------------------------------------
   //  Data members


### PR DESCRIPTION
## Summary
- update `FuncDecl` to store positional, default, vararg, and kwarg info
- dump function parameters when debugging AST
- extend parser to understand Python-style parameter lists
- handle new `FuncDecl` shape during codegen

## Testing
- `cmake -S . -B build -DRLVM_BUILD_TESTS=ON` *(passed)*
- `cmake --build build` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d811d108324baa7e0129f33026a