### PR TITLE
Implement bound methods and foreign instances

### DIFF
--- a/src/libsiglus/bindings/sdl.cpp
+++ b/src/libsiglus/bindings/sdl.cpp
@@ -52,7 +52,7 @@ void SDL::Bind(sr::VM& vm) {
       "__init__",
       gc->Allocate<sr::NativeFunction>(
           "__init__",
-          [](sr::VM& vm, sr::Fiber&, sr::Value self, std::vector<sr::Value>,
+          [](sr::VM& vm, sr::Fiber&, std::vector<sr::Value>,
              std::unordered_map<std::string, sr::Value>) -> sr::Value {
             if (SDL_Init(SDL_INIT_VIDEO) < 0) {
               throw std::runtime_error(
@@ -112,8 +112,7 @@ void SDL::Bind(sr::VM& vm) {
       "play",
       gc->Allocate<sr::NativeFunction>(
           "play",
-          [](sr::VM& vm, sr::Fiber&, sr::Value self,
-             std::vector<sr::Value> args,
+          [](sr::VM& vm, sr::Fiber&, std::vector<sr::Value> args,
              std::unordered_map<std::string, sr::Value>) -> sr::Value {
             std::string* name;
             if (args.size() < 1 ||
@@ -132,8 +131,7 @@ void SDL::Bind(sr::VM& vm) {
   sdl->memfns.try_emplace(
       "bgm", gc->Allocate<sr::NativeFunction>(
                  "bgm",
-                 [](sr::VM& vm, sr::Fiber&, sr::Value self,
-                    std::vector<sr::Value> args,
+                 [](sr::VM& vm, sr::Fiber&, std::vector<sr::Value> args,
                     std::unordered_map<std::string, sr::Value>) -> sr::Value {
                    std::string* name;
                    if (args.size() < 1 ||

--- a/src/libsiglus/bindings/sdl.cpp
+++ b/src/libsiglus/bindings/sdl.cpp
@@ -48,7 +48,7 @@ void SDL::Bind(sr::VM& vm) {
 
   sr::Class* sdl = gc->Allocate<sr::Class>();
   sdl->name = "sdl";
-  sdl->methods.try_emplace(
+  sdl->memfns.try_emplace(
       "__init__",
       gc->Allocate<sr::NativeFunction>(
           "__init__",
@@ -108,7 +108,7 @@ void SDL::Bind(sr::VM& vm) {
 
             return sr::Value(true);
           }));
-  sdl->methods.try_emplace(
+  sdl->memfns.try_emplace(
       "play",
       gc->Allocate<sr::NativeFunction>(
           "play",
@@ -129,7 +129,7 @@ void SDL::Bind(sr::VM& vm) {
 
             return sr::Value(true);
           }));
-  sdl->methods.try_emplace(
+  sdl->memfns.try_emplace(
       "bgm", gc->Allocate<sr::NativeFunction>(
                  "bgm",
                  [](sr::VM& vm, sr::Fiber&, sr::Value self,

--- a/src/libsiglus/bindings/sdl.cpp
+++ b/src/libsiglus/bindings/sdl.cpp
@@ -52,7 +52,7 @@ void SDL::Bind(sr::VM& vm) {
       "__init__",
       gc->Allocate<sr::NativeFunction>(
           "__init__",
-          [](sr::Fiber&, std::vector<sr::Value>,
+          [](sr::VM& vm, sr::Fiber&, sr::Value self, std::vector<sr::Value>,
              std::unordered_map<std::string, sr::Value>) -> sr::Value {
             if (SDL_Init(SDL_INIT_VIDEO) < 0) {
               throw std::runtime_error(
@@ -112,7 +112,8 @@ void SDL::Bind(sr::VM& vm) {
       "play",
       gc->Allocate<sr::NativeFunction>(
           "play",
-          [](sr::Fiber&, std::vector<sr::Value> args,
+          [](sr::VM& vm, sr::Fiber&, sr::Value self,
+             std::vector<sr::Value> args,
              std::unordered_map<std::string, sr::Value>) -> sr::Value {
             std::string* name;
             if (args.size() < 1 ||
@@ -128,27 +129,26 @@ void SDL::Bind(sr::VM& vm) {
 
             return sr::Value(true);
           }));
-    sdl->methods.try_emplace(
-      "bgm",
-      gc->Allocate<sr::NativeFunction>(
-          "bgm",
-          [](sr::Fiber&, std::vector<sr::Value> args,
-             std::unordered_map<std::string, sr::Value>) -> sr::Value {
-            std::string* name;
-            if (args.size() < 1 ||
-                ((name = args.front().Get_if<std::string>()) == nullptr))
-              throw std::runtime_error(
-                  "Bgm: first argument 'file_name' must be string");
+  sdl->methods.try_emplace(
+      "bgm", gc->Allocate<sr::NativeFunction>(
+                 "bgm",
+                 [](sr::VM& vm, sr::Fiber&, sr::Value self,
+                    std::vector<sr::Value> args,
+                    std::unordered_map<std::string, sr::Value>) -> sr::Value {
+                   std::string* name;
+                   if (args.size() < 1 ||
+                       ((name = args.front().Get_if<std::string>()) == nullptr))
+                     throw std::runtime_error(
+                         "Bgm: first argument 'file_name' must be string");
 
-            fs::path path = scanner->FindFile(*name);
-            player_t player = CreateAudioPlayer(path);
+                   fs::path path = scanner->FindFile(*name);
+                   player_t player = CreateAudioPlayer(path);
 
-	    sound_impl->EnableBgm();
-	    sound_impl->PlayBgm(player);
+                   sound_impl->EnableBgm();
+                   sound_impl->PlayBgm(player);
 
-            return sr::Value(true);
-          }));
-
+                   return sr::Value(true);
+                 }));
 
   vm.globals_->map["sdl"] = sr::Value(sdl);
 }

--- a/src/m6/ast.cpp
+++ b/src/m6/ast.cpp
@@ -230,9 +230,14 @@ struct Dumper {
       oss << x.body->DumpAST("body", childPrefix, true);
     }
     if constexpr (std::same_as<T, ClassDecl>) {
-      for (size_t i = 0; i < x.members.size(); ++i) {
-        Dumper dumper(childPrefix, i + 1 >= x.members.size());
-        oss << dumper(x.members[i]);
+      for (size_t i = 0; i < x.memfn.size(); ++i) {
+        Dumper dumper(childPrefix,
+                      (i + 1 >= x.memfn.size()) && x.staticfn.empty());
+        oss << dumper(x.memfn[i]);
+      }
+      for (size_t i = 0; i < x.staticfn.size(); ++i) {
+        Dumper dumper(childPrefix, i + 1 >= x.staticfn.size());
+        oss << dumper(x.staticfn[i]);
       }
     }
     if constexpr (std::same_as<T, ReturnStmt>) {

--- a/src/m6/ast.hpp
+++ b/src/m6/ast.hpp
@@ -282,7 +282,7 @@ struct FuncDecl {
 
 struct ClassDecl {
   std::string name;
-  std::vector<FuncDecl> members;
+  std::vector<FuncDecl> memfn, staticfn;
 
   SourceLocation name_loc;
 

--- a/src/m6/codegen.cpp
+++ b/src/m6/codegen.cpp
@@ -420,12 +420,17 @@ void CodeGenerator::emit_stmt_node(const FuncDecl& fn) {
 }
 
 void CodeGenerator::emit_stmt_node(const ClassDecl& cd) {
-  for (auto& m : cd.members) {
+  for (auto& m : cd.memfn) {
+    emit(sr::Push{constant(Value(m.name))});
+    emit_function(m);
+  }
+  for (auto& m : cd.staticfn) {
     emit(sr::Push{constant(Value(m.name))});
     emit_function(m);
   }
   emit(sr::MakeClass{intern_name(cd.name),
-                     static_cast<uint16_t>(cd.members.size())});
+                     static_cast<uint16_t>(cd.memfn.size()),
+                     static_cast<uint16_t>(cd.staticfn.size())});
   emit(sr::StoreGlobal{intern_name(cd.name)});
 }
 

--- a/src/m6/codegen.hpp
+++ b/src/m6/codegen.hpp
@@ -60,9 +60,6 @@ class CodeGenerator {
   // -- Type aliases ----------------------------------------------------
   using Value = serilang::Value;
   enum class SCOPE { NONE = 1, GLOBAL, LOCAL };
-  template <typename T>
-  using Map_t =
-      std::unordered_map<std::string, T, TransparentHash, TransparentEq>;
 
   // -- Data members ---------------------------------------------------
   std::shared_ptr<serilang::GarbageCollector> gc_;
@@ -70,8 +67,8 @@ class CodeGenerator {
   bool in_function_;
 
   serilang::Code* chunk_;
-  Map_t<SCOPE> scope_heuristic_;
-  Map_t<std::size_t> locals_;
+  transparent_hashmap<SCOPE> scope_heuristic_;
+  transparent_hashmap<std::size_t> locals_;
   std::size_t local_depth_;
   std::vector<Error> errors_;
 

--- a/src/m6/vm_factory.cpp
+++ b/src/m6/vm_factory.cpp
@@ -45,8 +45,7 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
           {"time",
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "time",
-               [](sr::VM& vm, sr::Fiber& f, sr::Value self,
-                  std::vector<sr::Value> args,
+               [](sr::VM& vm, sr::Fiber& f, std::vector<sr::Value> args,
                   std::unordered_map<std::string, sr::Value> /*kwargs*/) {
                  if (!args.empty())
                    throw std::runtime_error("time() takes no arguments");
@@ -59,8 +58,7 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
           {"print",
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "print",
-               [&stdout](sr::VM& vm, sr::Fiber& f, sr::Value self,
-                         std::vector<sr::Value> args,
+               [&stdout](sr::VM& vm, sr::Fiber& f, std::vector<sr::Value> args,
                          std::unordered_map<std::string, sr::Value> kwargs) {
                  std::string sep = " ";
                  if (auto it = kwargs.find("sep"); it != kwargs.end())
@@ -94,8 +92,7 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
           {"input",
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "input",
-               [&stdin](sr::VM& vm, sr::Fiber& f, sr::Value self,
-                        std::vector<sr::Value> args,
+               [&stdin](sr::VM& vm, sr::Fiber& f, std::vector<sr::Value> args,
                         std::unordered_map<std::string, sr::Value> kwargs) {
                  std::string inp;
                  stdin >> inp;
@@ -106,8 +103,7 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "import",
                [&vm, &stdin, &stdout, &stderr](
-                   sr::VM& vm2, sr::Fiber& f, sr::Value self,
-                   std::vector<sr::Value> args,
+                   sr::VM& vm2, sr::Fiber& f, std::vector<sr::Value> args,
                    std::unordered_map<std::string, sr::Value> /*kwargs*/) {
                  if (args.size() != 1)
                    throw std::runtime_error("import() expects module name");

--- a/src/m6/vm_factory.cpp
+++ b/src/m6/vm_factory.cpp
@@ -45,7 +45,8 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
           {"time",
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "time",
-               [](sr::Fiber& f, std::vector<sr::Value> args,
+               [](sr::VM& vm, sr::Fiber& f, sr::Value self,
+                  std::vector<sr::Value> args,
                   std::unordered_map<std::string, sr::Value> /*kwargs*/) {
                  if (!args.empty())
                    throw std::runtime_error("time() takes no arguments");
@@ -58,7 +59,8 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
           {"print",
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "print",
-               [&stdout](sr::Fiber& f, std::vector<sr::Value> args,
+               [&stdout](sr::VM& vm, sr::Fiber& f, sr::Value self,
+                         std::vector<sr::Value> args,
                          std::unordered_map<std::string, sr::Value> kwargs) {
                  std::string sep = " ";
                  if (auto it = kwargs.find("sep"); it != kwargs.end())
@@ -92,7 +94,8 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
           {"input",
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "input",
-               [&stdin](sr::Fiber& f, std::vector<sr::Value> args,
+               [&stdin](sr::VM& vm, sr::Fiber& f, sr::Value self,
+                        std::vector<sr::Value> args,
                         std::unordered_map<std::string, sr::Value> kwargs) {
                  std::string inp;
                  stdin >> inp;
@@ -103,7 +106,8 @@ sr::VM VMFactory::Create(std::shared_ptr<sr::GarbageCollector> gc,
            sr::Value(gc->Allocate<sr::NativeFunction>(
                "import",
                [&vm, &stdin, &stdout, &stderr](
-                   sr::Fiber& f, std::vector<sr::Value> args,
+                   sr::VM& vm2, sr::Fiber& f, sr::Value self,
+                   std::vector<sr::Value> args,
                    std::unordered_map<std::string, sr::Value> /*kwargs*/) {
                  if (args.size() != 1)
                    throw std::runtime_error("import() expects module name");

--- a/src/utilities/transparent_hash.hpp
+++ b/src/utilities/transparent_hash.hpp
@@ -26,6 +26,8 @@
 
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 
 struct TransparentHash {
   using is_transparent = void;
@@ -44,3 +46,11 @@ struct TransparentEq {
     return a == b;
   }
 };
+
+template <typename T>
+using transparent_hashmap =
+    std::unordered_map<std::string, T, TransparentHash, TransparentEq>;
+
+template <typename T>
+using transparent_hashset =
+    std::unordered_set<std::string, T, TransparentHash, TransparentEq>;

--- a/src/vm/disassembler.cpp
+++ b/src/vm/disassembler.cpp
@@ -220,8 +220,8 @@ void Disassembler::PrintIns(Code& chunk,
       ip += sizeof(ins);
       emit_mnemonic("MAKE_CLASS");
       emit_operand("");
-      out_ << std::format("name={}({})  nmethods={}", ins.name_index,
-                          string_at(ins.name_index), ins.nmethods);
+      out_ << std::format("name={}({})  nmem={}  nstatic={}", ins.name_index,
+                          string_at(ins.name_index), ins.nmemfn, ins.nstaticfn);
     } break;
     case OpCode::GetField: {
       const auto ins = chunk.Read<GetField>(ip);

--- a/src/vm/instruction.hpp
+++ b/src/vm/instruction.hpp
@@ -110,8 +110,8 @@ struct MakeDict {
 };  // (key,val,...) -> (dict)
 struct MakeClass {
   uint32_t name_index;
-  uint16_t nmethods;
-};  // (method_fn*) -> (class)
+  uint16_t nmemfn, nstaticfn;
+};  // (mem_fn*, static_fn*) -> (class)
 struct GetField {
   uint32_t name_index;
 };  // (inst) -> (value)
@@ -127,7 +127,7 @@ struct MakeFiber {
   uint32_t kwargcnt;
 };  // (…) -> (fiber)
 struct Await {};  // (fiber,arg) -> (result|exc)
-struct Yield {};   // (value) -> (yielded)
+struct Yield {};  // (value) -> (yielded)
 //  ‣ `Yield` suspends the *current* fiber and returns control to its resumer
 //  ‣ `Resume` runs the fiber until next `Yield` or `Return`
 

--- a/src/vm/object.hpp
+++ b/src/vm/object.hpp
@@ -33,8 +33,8 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -302,16 +302,20 @@ class NativeFunction : public IObject {
  public:
   static constexpr inline ObjType objtype = ObjType::Native;
 
-  using function_t =
-      std::function<Value(VM&,
-                          Fiber&,
-                          Value,
-                          std::vector<Value>,
-                          std::unordered_map<std::string, Value>)>;
+  using function_t = std::function<Value(VM&,
+                                         Fiber&,
+                                         uint8_t,
+                                         uint8_t  // nargs, nkwargs
+                                         )>;
 
+  [[deprecated]]
   NativeFunction(std::string name,
-                 function_t fn,
-                 std::vector<Value> captures = {});
+                 std::function<Value(VM&,
+                                     Fiber&,
+                                     std::vector<Value>,
+                                     std::unordered_map<std::string, Value>)>);
+
+  NativeFunction(std::string name, function_t fn);
 
   std::string Name() const;
   constexpr ObjType Type() const noexcept final { return objtype; }
@@ -324,16 +328,9 @@ class NativeFunction : public IObject {
 
   void Call(VM& vm, Fiber& f, uint8_t nargs, uint8_t nkwargs) final;
 
-  Value Invoke(VM& vm,
-               Fiber& f,
-               Value self,
-               std::vector<Value> args,
-               std::unordered_map<std::string, Value> kwargs);
-
  private:
   std::string name_;
   function_t fn_;
-  std::vector<Value> captures_;
 };
 
 struct BoundMethod : public IObject {

--- a/src/vm/object.hpp
+++ b/src/vm/object.hpp
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "utilities/transparent_hash.hpp"
 #include "vm/call_frame.hpp"
 #include "vm/instruction.hpp"
 #include "vm/iobject.hpp"
@@ -95,7 +96,8 @@ struct Class : public IObject {
   static constexpr inline ObjType objtype = ObjType::Class;
 
   std::string name;
-  std::unordered_map<std::string, Value> methods;
+  transparent_hashmap<Value> memfns;
+  transparent_hashmap<Value> fields;
 
   constexpr ObjType Type() const noexcept final { return objtype; }
   constexpr size_t Size() const noexcept final { return sizeof(*this); }
@@ -112,7 +114,7 @@ struct Instance : public IObject {
   static constexpr inline ObjType objtype = ObjType::Instance;
 
   Class* klass;
-  std::unordered_map<std::string, Value> fields;
+  transparent_hashmap<Value> fields;
   explicit Instance(Class* klass_);
 
   constexpr ObjType Type() const noexcept final { return objtype; }
@@ -134,7 +136,7 @@ struct NativeClass : public IObject {
   using trace_fn = void (*)(GCVisitor&, void*);
 
   std::string name;
-  std::unordered_map<std::string, Value> methods;
+  transparent_hashmap<Value> methods;
   finalize_fn finalize = nullptr;
   trace_fn trace = nullptr;
 
@@ -153,7 +155,7 @@ struct NativeInstance : public IObject {
   static constexpr inline ObjType objtype = ObjType::NativeInstance;
 
   NativeClass* klass;
-  std::unordered_map<std::string, Value> fields;
+  transparent_hashmap<Value> fields;
   void* foreign = nullptr;
 
   explicit NativeInstance(NativeClass* klass_);

--- a/src/vm/objtype.hpp
+++ b/src/vm/objtype.hpp
@@ -40,6 +40,7 @@ enum class ObjType : uint8_t {
   Dict,
   Module,
   Native,
+  BoundMethod,
   Code,
   Function,
   Closure,

--- a/src/vm/objtype.hpp
+++ b/src/vm/objtype.hpp
@@ -41,6 +41,8 @@ enum class ObjType : uint8_t {
   Module,
   Native,
   BoundMethod,
+  NativeClass,
+  NativeInstance,
   Code,
   Function,
   Closure,

--- a/src/vm/value_fwd.hpp
+++ b/src/vm/value_fwd.hpp
@@ -38,6 +38,7 @@ struct List;
 struct Dict;
 struct Function;
 class NativeFunction;
+struct BoundMethod;
 
 class Value;
 class IObject;

--- a/src/vm/value_fwd.hpp
+++ b/src/vm/value_fwd.hpp
@@ -32,6 +32,8 @@ namespace serilang {
 struct Code;
 struct Class;
 struct Instance;
+struct NativeClass;
+struct NativeInstance;
 struct Upvalue;
 struct Fiber;
 struct List;

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -445,11 +445,17 @@ void VM::ExecuteFiber(Fiber* fib) {
         auto klass = gc_->Allocate<Class>();
         klass->name =
             chunk->const_pool[ins.name_index].template Get<std::string>();
-        for (int i = 0; i < ins.nmethods; i++) {
+        for (int i = 0; i < ins.nstaticfn; i++) {
           auto method = pop(fib->stack);
           auto name = pop(fib->stack).template Get<std::string>();
-          klass->methods[std::move(name)] = std::move(method);
+          klass->fields.try_emplace(std::move(name), std::move(method));
         }
+        for (int i = 0; i < ins.nmemfn; i++) {
+          auto method = pop(fib->stack);
+          auto name = pop(fib->stack).template Get<std::string>();
+          klass->memfns.try_emplace(std::move(name), std::move(method));
+        }
+
         push(fib->stack, Value(klass));
       } break;
 

--- a/test/gc_unittest.cpp
+++ b/test/gc_unittest.cpp
@@ -238,7 +238,7 @@ TEST_F(GCTest, MixedValueGraph) {
   // Class+Instance: instance.field → dict, class.method → closure
   auto* klass = Alloc<Class>();
   klass->name = "Mixed";
-  klass->methods["fn"] = Value(fn);
+  klass->memfns["fn"] = Value(fn);
   auto* inst = Alloc<Instance>(klass);
   inst->fields["data"] = Value(dict);
 

--- a/test/m6/compiler_test.cpp
+++ b/test/m6/compiler_test.cpp
@@ -341,16 +341,18 @@ print(klass, klass.foo(), klass.boo(2,3), end="", sep=",");
 
   {
     auto res = Run(R"(
-class Klass{}
-fn foo(self, x){
-  self.result += "*" * x + "0";
-  if(x > 1) foo(self, x-1);
+class Klass{
+  fn foo(self, x){
+    self.result += "*" * x + "0";
+    if(x > 1) foo(self, x-1);
+  }
 }
 
 inst = Klass();
 inst.result = "";
-inst.method = foo;
-inst.method(inst, 5);
+
+foo = inst.foo;
+foo(5);
 
 print(inst.result);
 )");

--- a/test/m6/parser_unittest.cpp
+++ b/test/m6/parser_unittest.cpp
@@ -851,9 +851,12 @@ fn kw_only(a,b,c,*args)
 }
 
 TEST_F(StmtParserTest, ClassDecl) {
-  expectStmtAST(TokenArray("class Klass{ fn foo(){} fn boo(a,b,c){} }"),
+  expectStmtAST(TokenArray("class Klass{ fn foo(){} fn boo(a,b,c){} fn moo(self,a){} }"),
                 R"(
 class Klass
+   ├─fn moo(self,a)
+   │  └─body
+   │     └─Compound
    ├─fn foo()
    │  └─body
    │     └─Compound

--- a/test/vm_unittest.cpp
+++ b/test/vm_unittest.cpp
@@ -149,7 +149,7 @@ TEST_F(VMTest, CallNative) {
 
   int call_count = 0;
   auto fn = gc->Allocate<NativeFunction>(
-      "my_function", [&](Fiber& f, std::vector<Value> args,
+      "my_function", [&](VM& vm, Fiber& f, Value self, std::vector<Value> args,
                          std::unordered_map<std::string, Value> kwargs) {
         ++call_count;
         EXPECT_EQ(args.size(), 2);
@@ -216,7 +216,7 @@ TEST_F(VMTest, SpawnFiber) {
   std::vector<Value> arg;
   std::unordered_map<std::string, Value> kwarg;
   auto* fn = gc->Allocate<NativeFunction>(
-      "my_function", [&](Fiber& f, std::vector<Value> args,
+      "my_function", [&](VM& vm, Fiber& f, Value self, std::vector<Value> args,
                          std::unordered_map<std::string, Value> kwargs) {
         ++call_count;
         arg = std::move(args);


### PR DESCRIPTION
## Summary
- add `BoundMethod` object type
- allow classes to own native pointers with finalize/trace hooks
- extend `NativeFunction` to expose receiver and VM
- add bound method handling in `Instance::Member`
- update builtins, tests and SDL bindings

## Testing
- `cmake -S . -B build -DRLVM_BUILD_TESTS=ON`
- `cmake --build build -j 4`
- `./build/unittest` *(fails: CompilerTest.Class)*

------
https://chatgpt.com/codex/tasks/task_e_688bc8a7d2988324823936bbbabda5b4